### PR TITLE
Fix Q&A transition bugs

### DIFF
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,9 +1,9 @@
 import { config } from "@qnaplus/config"
-import pino from "pino"
+import pino, { LoggerOptions } from "pino"
 
-export const getLoggerInstance = (stream: string) => {
+export const getLoggerInstance = (stream: string, options?: LoggerOptions) => {
     return pino({
-        level: "trace",
+        ...options,
         transport: {
             targets: [
                 {

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -3,6 +3,7 @@ import pino from "pino"
 
 export const getLoggerInstance = (stream: string) => {
     return pino({
+        level: "trace",
         transport: {
             targets: [
                 {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -19,7 +19,7 @@
     "@supabase/supabase-js": "^2.39.3",
     "diff": "^5.1.0",
     "pino": "^8.17.2",
-    "vex-qna-archiver": "^8.1.3"
+    "vex-qna-archiver": "^9.0.0"
   },
   "devDependencies": {
     "@types/diff": "^5.0.9"

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -11,15 +11,15 @@
   },
   "scripts": {
     "build": "tsc --build",
-    "updater": "node dist/services/update_service.js",
-    "populate": "node dist/services/populate_service.js"
+    "populate": "node dist/populate.js",
+    "populate_with_metadata": "node dist/populate_with_metadata.js"
   },
   "dependencies": {
     "@qnaplus/config": "1.0.0",
     "@supabase/supabase-js": "^2.39.3",
     "diff": "^5.1.0",
     "pino": "^8.17.2",
-    "vex-qna-archiver": "^9.0.0"
+    "vex-qna-archiver": "^10.0.0"
   },
   "devDependencies": {
     "@types/diff": "^5.0.9"

--- a/packages/store/src/populate_with_metadata.ts
+++ b/packages/store/src/populate_with_metadata.ts
@@ -1,0 +1,7 @@
+import pino from "pino";
+import { populateWithMetadata } from "./database";
+
+(async () => {
+    const logger = pino();
+    populateWithMetadata(logger)
+})();

--- a/packages/store/src/supabase.ts
+++ b/packages/store/src/supabase.ts
@@ -6,7 +6,7 @@ export type Json =
   | { [key: string]: Json | undefined }
   | Json[]
 
-export interface Database {
+export type Database = {
   public: {
     Tables: {
       questions: {
@@ -66,6 +66,81 @@ export interface Database {
         }
         Relationships: []
       }
+      questions_duplicate: {
+        Row: {
+          answer: string | null
+          answered: boolean
+          answeredTimestamp: string | null
+          answeredTimestampMs: number | null
+          answerRaw: string | null
+          askedTimestamp: string | null
+          askedTimestampMs: number | null
+          author: string
+          id: string
+          program: string
+          question: string
+          questionRaw: string
+          season: string
+          tags: string[]
+          title: string
+          url: string
+        }
+        Insert: {
+          answer?: string | null
+          answered: boolean
+          answeredTimestamp?: string | null
+          answeredTimestampMs?: number | null
+          answerRaw?: string | null
+          askedTimestamp?: string | null
+          askedTimestampMs?: number | null
+          author: string
+          id: string
+          program: string
+          question: string
+          questionRaw: string
+          season: string
+          tags: string[]
+          title: string
+          url: string
+        }
+        Update: {
+          answer?: string | null
+          answered?: boolean
+          answeredTimestamp?: string | null
+          answeredTimestampMs?: number | null
+          answerRaw?: string | null
+          askedTimestamp?: string | null
+          askedTimestampMs?: number | null
+          author?: string
+          id?: string
+          program?: string
+          question?: string
+          questionRaw?: string
+          season?: string
+          tags?: string[]
+          title?: string
+          url?: string
+        }
+        Relationships: []
+      }
+      questions_metadata: {
+        Row: {
+          current_season: string | null
+          id: number
+          oldest_unanswered_question: string
+        }
+        Insert: {
+          current_season?: string | null
+          id?: number
+          oldest_unanswered_question: string
+        }
+        Update: {
+          current_season?: string | null
+          id?: number
+          oldest_unanswered_question?: string
+        }
+        Relationships: []
+      }
     }
     Views: {
       [_ in never]: never
@@ -82,14 +157,16 @@ export interface Database {
   }
 }
 
+type PublicSchema = Database[Extract<keyof Database, "public">]
+
 export type Tables<
   PublicTableNameOrOptions extends
-    | keyof (Database["public"]["Tables"] & Database["public"]["Views"])
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
         Database[PublicTableNameOrOptions["schema"]]["Views"])
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
       Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
@@ -97,67 +174,67 @@ export type Tables<
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (Database["public"]["Tables"] &
-      Database["public"]["Views"])
-  ? (Database["public"]["Tables"] &
-      Database["public"]["Views"])[PublicTableNameOrOptions] extends {
-      Row: infer R
-    }
-    ? R
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
     : never
-  : never
 
 export type TablesInsert<
   PublicTableNameOrOptions extends
-    | keyof Database["public"]["Tables"]
+    | keyof PublicSchema["Tables"]
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : PublicTableNameOrOptions extends keyof Database["public"]["Tables"]
-  ? Database["public"]["Tables"][PublicTableNameOrOptions] extends {
-      Insert: infer I
-    }
-    ? I
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
     : never
-  : never
 
 export type TablesUpdate<
   PublicTableNameOrOptions extends
-    | keyof Database["public"]["Tables"]
+    | keyof PublicSchema["Tables"]
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : PublicTableNameOrOptions extends keyof Database["public"]["Tables"]
-  ? Database["public"]["Tables"][PublicTableNameOrOptions] extends {
-      Update: infer U
-    }
-    ? U
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
     : never
-  : never
 
 export type Enums<
   PublicEnumNameOrOptions extends
-    | keyof Database["public"]["Enums"]
+    | keyof PublicSchema["Enums"]
     | { schema: keyof Database },
   EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
-    : never = never
+    : never = never,
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
   ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : PublicEnumNameOrOptions extends keyof Database["public"]["Enums"]
-  ? Database["public"]["Enums"][PublicEnumNameOrOptions]
-  : never
+  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never

--- a/services/bot/package.json
+++ b/services/bot/package.json
@@ -23,6 +23,6 @@
   },
   "devDependencies": {
     "pino-pretty": "^10.3.1",
-    "vex-qna-archiver": "^8.1.3"
+    "vex-qna-archiver": "^9.0.0"
   }
 }

--- a/services/bot/package.json
+++ b/services/bot/package.json
@@ -23,6 +23,6 @@
   },
   "devDependencies": {
     "pino-pretty": "^10.3.1",
-    "vex-qna-archiver": "^9.0.0"
+    "vex-qna-archiver": "^10.0.0"
   }
 }

--- a/services/web/package.json
+++ b/services/web/package.json
@@ -25,7 +25,7 @@
     "@vitejs/plugin-vue": "^5.0.3",
     "sass": "^1.71.1",
     "typescript": "^5.2.2",
-    "vex-qna-archiver": "^9.0.0",
+    "vex-qna-archiver": "^10.0.0",
     "vite": "^5.1.0",
     "vue-tsc": "^1.8.27"
   },

--- a/services/web/package.json
+++ b/services/web/package.json
@@ -25,7 +25,7 @@
     "@vitejs/plugin-vue": "^5.0.3",
     "sass": "^1.71.1",
     "typescript": "^5.2.2",
-    "vex-qna-archiver": "^8.1.3",
+    "vex-qna-archiver": "^9.0.0",
     "vite": "^5.1.0",
     "vue-tsc": "^1.8.27"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3508,10 +3508,10 @@ vali-date@^1.0.0:
   resolved "https://registry.yarnpkg.com/vali-date/-/vali-date-1.0.0.tgz#1b904a59609fb328ef078138420934f6b86709a6"
   integrity sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==
 
-vex-qna-archiver@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/vex-qna-archiver/-/vex-qna-archiver-9.0.0.tgz#dcb37ab2bb07b50b9d140c280034283dd3209ca4"
-  integrity sha512-NiUFEy7bqNeeoQoyHTI7aGunkT3unVxH2lGRmOgJY2lD9k8QC3DgDRzdIUI1DWQzBlfykrMtF9yiIeUfd3S0kA==
+vex-qna-archiver@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/vex-qna-archiver/-/vex-qna-archiver-10.0.0.tgz#29e2bc2a98011e3728f62469f1f9358ba99d45b4"
+  integrity sha512-irg1GthxFF6pdAAVPZ0MOSHs2H+kys9bsrTjjXBWzOWCNGjDHRUQV9HpzLlL5idhkQW5O1RO2BfQdC4uv4N/yw==
   dependencies:
     "@crawlee/core" "^3.7.2"
     cheerio "^1.0.0-rc.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3508,10 +3508,10 @@ vali-date@^1.0.0:
   resolved "https://registry.yarnpkg.com/vali-date/-/vali-date-1.0.0.tgz#1b904a59609fb328ef078138420934f6b86709a6"
   integrity sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==
 
-vex-qna-archiver@^8.1.3:
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/vex-qna-archiver/-/vex-qna-archiver-8.1.3.tgz#838c8791a9edc2183e029f485a79ba5a86588deb"
-  integrity sha512-LshAQxSpG+yiy7q93meQ9L8983lUMLR0QReyUbHszQgCI2xxC8Gnf0fcyb26K8CPNDvXUb7c1bHg7zUGVK2iVA==
+vex-qna-archiver@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/vex-qna-archiver/-/vex-qna-archiver-9.0.0.tgz#dcb37ab2bb07b50b9d140c280034283dd3209ca4"
+  integrity sha512-NiUFEy7bqNeeoQoyHTI7aGunkT3unVxH2lGRmOgJY2lD9k8QC3DgDRzdIUI1DWQzBlfykrMtF9yiIeUfd3S0kA==
   dependencies:
     "@crawlee/core" "^3.7.2"
     cheerio "^1.0.0-rc.12"


### PR DESCRIPTION
Fixes a number of bugs introduced/observed from the new Q&A forum release.
- `VRC` is now `V5RC`
- `VEXU` is now `VURC`
- `update` function now persists the oldest unanswered question in a metadata table instead of fetching it on-demand (provides a fallback to use when a new season rolls around)
- New script for populating the questions and metadata tables.